### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@ pinball-trainer-plus/
 ├── UPTP.pas                       # Main form unit — trainer logic, memory R/W, DLL injection
 ├── UPTP.dfm                       # Main form visual layout (Delphi Form Designer file)
 ├── SpeedHack/
+│   ├── Clear.bat                  # Cleanup script for SpeedHack build artifacts
 │   ├── SpeedHack.dpr              # Speed hack DLL project file
 │   ├── SpeedHack.res              # DLL compiled resources
 │   └── USpeedHack.pas             # Speed hack implementation (API hooking, timing override)
@@ -44,6 +45,7 @@ pinball-trainer-plus/
 │   └── Installer.res              # Embedded Pinball installer resource
 ├── Imgs/
 │   └── Icon.ico                   # Application icon
+├── CHANGELOG.md
 ├── Clear.bat                       # Cleanup script for Delphi build artifacts
 ├── CONTRIBUTING.md
 ├── LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
+- created `CLAUDE.md` with project architecture, build steps, and conventions for Claude Code sessions
+
 ### Changed
+
+- refreshed `.github/copilot-instructions.md` repository structure to include `CHANGELOG.md` and `SpeedHack/Clear.bat`
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Pinball Trainer Plus is a discontinued (2013) game trainer for 3D Pinball for Windows - Space Cadet. Built with Object Pascal in Borland Delphi 7. No automated builds, tests, or CI.
+
+## Build
+
+All builds are manual in the Delphi 7 IDE:
+
+1. Compile `SpeedHack/SpeedHack.dpr` first (produces `SpeedHack.dll`)
+2. Compile `PTP.dpr` (produces the trainer executable)
+
+Run `Clear.bat` (root) or `SpeedHack/Clear.bat` to remove build artifacts.
+
+## Architecture
+
+Single-form VCL app (`UPTP.pas`) + injected DLL (`SpeedHack/USpeedHack.pas`).
+
+- **Process detection** — polls for `pinball.exe` via `CreateToolHelp32SnapShot`; finds window by class `1c7c22a0-9576-11ce-bf80-444553540000`
+- **Memory R/W** — `ReadProcessMemory`/`WriteProcessMemory` with pointer chains (base `$01025040`)
+- **DLL injection** — extracts DLL from embedded resources, injects via `VirtualAllocEx` + `CreateRemoteThread` + `LoadLibraryA`
+- **Speed hack** — DLL patches first 5 bytes of `GetTickCount`, `timeGetTime`, `QueryPerformanceCounter` with JMP to custom replacements
+- **Trainer-DLL IPC** — DLL reads trainer's `SpeedHackSpeed`, `SpeedHackSleep`, `SpeedHackActiv` variables from fixed memory offsets
+
+## Conventions
+
+- Type prefix `T` (e.g. `TFrmPTPPrincipal`)
+- Constants in `SCREAMING_SNAKE_CASE`
+- UI control names prefixed with `s` (AlphaControls)
+- UI labels in Portuguese (pt-BR); code and docs in English
+- Memory addresses as `DWORD` hex constants
+- Conventional commits (e.g. `chore:`, `fix:`)
+
+## Prerequisites
+
+- Borland Delphi 7 with AlphaControls component suite
+- Windows XP/7 32-bit
+- 3D Pinball for Windows - Space Cadet


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.