### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,14 +23,18 @@ There is no automated build system or package manager. Builds are done manually 
 
 Run `Clear.bat` to remove all Delphi build artifacts (`.obj`, `.dcu`, `.exe`, etc.) before a clean rebuild.
 
-There is no CI/CD pipeline and no automated test suite.
+There is no automated test suite. CI handles release tagging only (`.github/workflows/release.yaml`).
 
 ## Repository Structure
 
 ```
 pinball-trainer-plus/
 ├── .github/
-│   └── copilot-instructions.md   # This file
+│   ├── copilot-instructions.md    # This file
+│   └── workflows/
+│       └── release.yaml           # Release tagging CI workflow
+├── .gitignore
+├── CLAUDE.md                      # Claude Code guidance
 ├── PTP.dpr                        # Main application entry point (Delphi project file)
 ├── PTP.res                        # Compiled project resources
 ├── UPTP.pas                       # Main form unit — trainer logic, memory R/W, DLL injection
@@ -57,9 +61,9 @@ pinball-trainer-plus/
 | File | Purpose |
 |---|---|
 | `UPTP.pas` | All trainer logic: process detection, memory read/write, DLL injection, UI event handlers, freeze timers |
-| `USpeedHack.pas` | Speed hack DLL: inline x86 JMP patching of `GetTickCount`, `timeGetTime`, `QueryPerformanceCounter` |
+| `USpeedHack.pas` | Unused alternative speed hack implementation (not referenced by either project) |
 | `PTP.dpr` | Application entry point; references `UPTP` and links resources |
-| `SpeedHack/SpeedHack.dpr` | DLL entry point |
+| `SpeedHack/SpeedHack.dpr` | Speed hack DLL: full implementation including API hooking via inline x86 JMP patching, trainer IPC, and timing loop |
 | `UPTP.dfm` | Delphi form layout — edit in the Delphi IDE form designer |
 
 ## Technology Stack
@@ -87,13 +91,13 @@ The entire trainer is implemented as a single VCL form class `TFrmPTPPrincipal`.
 - **DLL injection** — `InjectDll()` extracts `SpeedHack.dll` from embedded resources via `CreateResource()`, allocates memory in the target process with `VirtualAllocEx`, writes the DLL path with `WriteProcessMemory`, and creates a remote thread that calls `LoadLibraryA`.
 - **Trainer–DLL communication** — After injection, the DLL finds the trainer's window (`TFrmPTPPrincipal`) and reads three variables from the trainer's own process memory at fixed offsets: `SpeedHackSpeed` (acceleration multiplier), `SpeedHackSleep` (thread sleep interval), `SpeedHackActiv` (active flag).
 
-### Speed Hack DLL (`USpeedHack.pas`)
+### Speed Hack DLL (`SpeedHack.dpr`)
 
 The DLL patches three Windows timing functions in-process:
 
 1. Saves the original first 5 bytes of `GetTickCount`, `timeGetTime`, and `QueryPerformanceCounter`
 2. Overwrites the first 5 bytes with an `E9` (JMP) instruction redirecting to custom replacements
-3. A high-priority background thread increments a virtual tick counter using the configured multiplier
+3. A background thread increments a virtual tick counter using the configured multiplier
 4. Hooked functions return the virtual tick value instead of real system time, causing the game to run faster or slower
 
 ### Key Memory Addresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct DLL source file reference (`SpeedHack.dpr` not `USpeedHack.pas`), acknowledge `release.yaml` CI workflow, and update repository structure
+
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Pinball Trainer Plus is a discontinued (2013) game trainer for 3D Pinball for Windows - Space Cadet. Built with Object Pascal in Borland Delphi 7. No automated builds, tests, or CI.
+Pinball Trainer Plus is a discontinued (2013) game trainer for 3D Pinball for Windows - Space Cadet. Built with Object Pascal in Borland Delphi 7. No automated builds or tests; CI handles release tagging only (`.github/workflows/release.yaml`).
 
 ## Build
 
@@ -17,7 +17,7 @@ Run `Clear.bat` (root) or `SpeedHack/Clear.bat` to remove build artifacts.
 
 ## Architecture
 
-Single-form VCL app (`UPTP.pas`) + injected DLL (`SpeedHack/USpeedHack.pas`).
+Single-form VCL app (`UPTP.pas`) + injected DLL (`SpeedHack/SpeedHack.dpr`).
 
 - **Process detection** — polls for `pinball.exe` via `CreateToolHelp32SnapShot`; finds window by class `1c7c22a0-9576-11ce-bf80-444553540000`
 - **Memory R/W** — `ReadProcessMemory`/`WriteProcessMemory` with pointer chains (base `$01025040`)


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.