### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -165,7 +165,7 @@ Because this project is discontinued, changes should be limited to documentation
 |---|---|
 | Change a memory address | Update the relevant constant in `UPTP.pas` and update the table in `README.md` |
 | Add a new freeze target | Add a new timer in the VCL form, hook it to `WriteMemoryBytes` calls |
-| Update the speed hack | Edit `USpeedHack.pas`, rebuild `SpeedHack.dpr`, re-embed the resulting DLL into `Resources/SpeedHack.res` |
+| Update the speed hack | Edit `SpeedHack/SpeedHack.dpr`, recompile it, re-embed the resulting DLL into `Resources/SpeedHack.res` |
 | Replace the bundled installer | Rebuild `Resources/Installer.res` from the new installer binary |
 | Remove build artifacts | Run `Clear.bat` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix stale `USpeedHack.pas` reference in Common Tasks (should be `SpeedHack/SpeedHack.dpr`)
+
 ## [1.1.1] - 2026-05-19
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.